### PR TITLE
Fix failing tests related to Verifiable Encryption

### DIFF
--- a/tests/vcp/test_framework/tests/framework_tests.rs
+++ b/tests/vcp/test_framework/tests/framework_tests.rs
@@ -491,7 +491,7 @@ macro_rules! initial_test_via_new_framework_test {
             #[test]
             fn adds_decrypt_req() {
                 let mut ts = tf::start_test($platform_api, vec![CREATE_POLICE_AUTHORITY.to_owned()]).unwrap();
-                tf::extend_test($platform_api, vec![CREATE_D_ISSUER.to_owned(),sign_d_cred(td::HOLDER_1.to_owned())], &mut ts).unwrap();
+                tf::extend_test($platform_api, vec![CREATE_D_ISSUER_WITH_VE.to_owned(),sign_d_cred(td::HOLDER_1.to_owned())], &mut ts).unwrap();
                 tf::extend_test($platform_api, vec![ENCRYPT_FOR_POLICE_AUTHORITY.to_owned(),], &mut ts).unwrap();
                 tf::extend_test($platform_api, vec![DECRYPT_FOR_POLICE_AUTHORITY.to_owned(),], &mut ts).unwrap();
                 let y = ts.decrypt_requests.get(&td::HOLDER_1.to_owned()).cloned().unwrap_or_default();

--- a/tests/vcp/test_framework/tests/framework_tests.rs
+++ b/tests/vcp/test_framework/tests/framework_tests.rs
@@ -145,18 +145,6 @@ macro_rules! pok_and_reveal_metadata_and_eqs_test {
     ($platform_api: expr) => {
         mod pok_and_reveal_metadata_and_eqs {
             use super::*;
-
-            // TODO: stop ignroing this test after figuring out why this test fails when testing_framework_test is invoked with
-            // DNC's CryptoInterface, even though essentially the same test via JSON passes:
-            //
-            // cargo test vcp::zkp_backends::ac2c::run_json_zkp_functionality_tests::bbs::test_001_reveal_attributes_from_two_credentials_equality_for_two_attributes
-            // test vcp::zkp_backends::ac2c::run_json_zkp_functionality_tests::bbs::test_001_reveal_attributes_from_two_credentials_equality_for_two_attributes ... ok
-            //
-            // cargo test vcp::zkp_backends::dnc::run_test_framework_tests::tests::testing_framework::pok_and_reveal_metadata_and_eqs::pok_and_reveal_metadata_and_eqs
-            // ---- vcp::zkp_backends::dnc::run_test_framework_tests::tests::testing_framework::pok_and_reveal_metadata_and_eqs::pok_and_reveal_metadata_and_eqs stdout ----
-            // thread 'vcp::zkp_backends::dnc::run_test_framework_tests::tests::testing_framework::pok_and_reveal_metadata_and_eqs::pok_and_reveal_metadata_and_eqs' panicked at tests/vcp/test_framework/utils.rs:144:37:
-            // called `Result::unwrap()` on an `Err` value: General("step_create_verify_proof; verify_proof expected to succeed, but failed; General(\"DNC prf.verify BBSPlusProofContributionFailed(1, SecondSchnorrVerificationFailed)\")")
-            #[ignore]
             #[test]
             fn pok_and_reveal_metadata_and_eqs() {
                 tf::run_test(

--- a/tests/vcp/zkp_functionality_tests/test_definitions.rs
+++ b/tests/vcp/zkp_functionality_tests/test_definitions.rs
@@ -66,6 +66,8 @@ pub fn sign_s_cred(h_lbl: tf::HolderLabel) -> tf::TestStep {
 lazy_static! {
     pub static ref CREATE_D_ISSUER: tf::TestStep =
         tf::TestStep::CreateIssuer(td::D_ISSUER_LABEL.to_owned(), td::D_CTS.to_vec());
+    pub static ref CREATE_D_ISSUER_WITH_VE: tf::TestStep =
+        tf::TestStep::CreateIssuer(td::D_ISSUER_LABEL.to_owned(), td::D_CTS_WITH_VE.to_vec());
     pub static ref CREATE_S_ISSUER: tf::TestStep =
         tf::TestStep::CreateIssuer(td::S_ISSUER_LABEL.to_owned(), td::S_CTS.to_vec());
     pub static ref CREATE_POLICE_AUTHORITY: tf::TestStep =

--- a/tests/vcp/zkp_functionality_tests/test_definitions.rs
+++ b/tests/vcp/zkp_functionality_tests/test_definitions.rs
@@ -65,7 +65,7 @@ pub fn sign_s_cred(h_lbl: tf::HolderLabel) -> tf::TestStep {
 
 lazy_static! {
     pub static ref CREATE_D_ISSUER: tf::TestStep =
-        tf::TestStep::CreateIssuer(td::D_ISSUER_LABEL.to_owned(), td::D_CTS_WITH_VE.to_vec());
+        tf::TestStep::CreateIssuer(td::D_ISSUER_LABEL.to_owned(), td::D_CTS.to_vec());
     pub static ref CREATE_S_ISSUER: tf::TestStep =
         tf::TestStep::CreateIssuer(td::S_ISSUER_LABEL.to_owned(), td::S_CTS.to_vec());
     pub static ref CREATE_POLICE_AUTHORITY: tf::TestStep =


### PR DESCRIPTION
This PR fixes a test that inadvertently required equality between two attributes with different `ClaimType`s (one `CTText`, one `CTEncryptableText`), which failed for DNC (it did not fail with AC2C because AC2C does not yet fully support Verifiable Encryption).

It also fixes another test that failed (for all three ZKP backends (DNC, AC2C with PS and with BBS), because it attempted to add a `DecryptionRequest` for an attribute with `CTText`.

All tests pass now:
```
$ make test
...
test result: ok. 205 passed; 0 failed; 8 ignored; 0 measured; 14 filtered out; finished in 1762.34s
```
