### PR TITLE
Check filename test description consistency, fix test framework bug

### DIFF
--- a/tests/vcp/test_framework/steps.rs
+++ b/tests/vcp/test_framework/steps.rs
@@ -638,6 +638,13 @@ pub fn step_create_and_verify_proof(
                 Ok(())
             },
             Ok(ref wadfv@WarningsAndDataForVerifier { warnings: ref create_warns, data_for_verifier: ref dfv }) => {
+                if let CreateProofFails(l) = &test_exp {
+                    return Err(Error::General(ic_semi(&str_vec_from!(
+                        "step_create_and_verify_proof",
+                        "create_proof expected to fail, but succeeded",
+                        "error expected to contain",
+                        format!("{l:?}")))))
+                };
                 let d_reqs = ts.decrypt_requests.get(&h_lbl).cloned().unwrap_or_default();
                 let res_v = verify_proof(
                     proof_reqs,
@@ -659,26 +666,25 @@ pub fn step_create_and_verify_proof(
                     },
                     Ok(WarningsAndDecryptResponses { warnings, decrypt_responses }) => {
                         match &test_exp {
-                            CreateVerifyExpectation::CreateProofFails(l) => {
+                            CreateProofFails(_) => {
                                 Err(Error::General(ic_semi(&str_vec_from!(
                                     "step_create_and_verify_proof",
-                                    "create_proof expected to fail, but succeeded",
-                                    "error expected to contain",
-                                    format!("{l:?}")))))
+                                    "IMPOSSIBLE",
+                                    "condition already checked"))))
                             }
-                            CreateVerifyExpectation::VerifyProofFails => {
+                            VerifyProofFails => {
                                 Err(Error::General(
                                     "step_create_and_verify_proof; verify_proof expected to fail, but succeeded"
                                         .to_string(),
                                 ))
                             }
-                            CreateVerifyExpectation::CreateOrVerifyFails => {
+                            CreateOrVerifyFails => {
                                 Err(Error::General(
                                     "step_create_and_verify_proof; create_proof or verify_proof expected to fail, but succeeded"
                                         .to_string(),
                                 ))
                             },
-                            CreateVerifyExpectation::BothSucceedNoWarnings => {
+                            BothSucceedNoWarnings => {
                                 if !create_warns.is_empty() || !warnings.is_empty() {
                                     return Err(Error::General(
                                         format!("step_create_and_verify_proof; expected no warnings, got; {create_warns:?}; {warnings:?}")))


### PR DESCRIPTION
This PR does two things, both related to running tests expressed in JSON:
* Confirms that the test filename follows the convention of having a `json_test_nnn_` prefix and a `.json` suffix, and confirms that the text between those is consistent with the name of the file (modulo capitalisation of "SLOW").  This helps to maintain consistency between the test description in test output and the file that defines the test, to avoid the confusion that can ensue when these are not consistent and one tries to debug the wrong failing test.
* Fixes a bug in the test framework that caused it not to fail with correct error messages when `create_proof` succeeded although expected to fail.