### PR TITLE
Fix test broken by reverting unnecessary changes to src

### DIFF
--- a/tests/flow.rs
+++ b/tests/flow.rs
@@ -732,7 +732,7 @@ fn test_blind_sign_request() -> CredxResult<()> {
     let cred_schema = CredentialSchema::new(
         Some(LABEL),
         Some(DESCRIPTION),
-        &["link_secret".to_string()],
+        &["link_secret"],
         &schema_claims,
     )?;
 


### PR DESCRIPTION
Missed a commit when reverting some unnecessary changes to `src` before merging.