### PR TITLE
Use new decryption capability of AC2C

### DIFF
--- a/generate-tests-from-json/Cargo.toml
+++ b/generate-tests-from-json/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "generate-tests-from-json"
 version = "0.0.0"
+edition = "2021"
 
 [lib]
 proc-macro = true

--- a/server/example-client/java/Makefile
+++ b/server/example-client/java/Makefile
@@ -81,13 +81,9 @@ test-equalities: reset-db
 test-range: reset-db
 	mvn test -Dtest="AppTest#testRange"
 
-.PHONY: test-verifiable-encryption-ac2c-bbs
-test-verifiable-encryption-ac2c-bbs: reset-db
-	mvn test -Dtest="AppTest#testVerifiableEncryptionAC2C_BBS"
-
-.PHONY: test-verifiable-encryption-ac2c-ps
-test-verifiable-encryption-ac2c-ps: reset-db
-	mvn test -Dtest="AppTest#testVerifiableEncryptionAC2C_PS"
+.PHONY: test-verifiable-encryption-ac2c
+test-verifiable-encryption-ac2c: reset-db
+	mvn test -Dtest="AppTest#testVerifiableEncryptionAC2C"
 
 .PHONY: test-verifiable-encryption-dnc
 test-verifiable-encryption-dnc: reset-db

--- a/server/example-client/java/src/main/java/com/example/vcp/demos/Util.java
+++ b/server/example-client/java/src/main/java/com/example/vcp/demos/Util.java
@@ -31,9 +31,22 @@ public class Util
         return  x.zkpLib + " " + x.sigType.toString();
     }
 
+    static void bannerAux(final String m) {
+        System.out.println();
+        System.out.println("------------------------- " + m + " -------------------------");
+    }
+
+    static String zpkLibAndSigTypeString(final X x) {
+        return  x.zkpLib + " " + x.sigType.toString();
+    }
+
+    static final boolean DO_PRINT = false;
+
     public static void sop(final String m, final Object o) {
-        // banner(m, "");
-        // System.out.println(o);
+        if (DO_PRINT) {
+            bannerAux(m);
+            System.out.println(o);
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/server/example-client/java/src/test/java/com/example/vcp/demos/AppTest.java
+++ b/server/example-client/java/src/test/java/com/example/vcp/demos/AppTest.java
@@ -165,13 +165,38 @@ public class AppTest
         expect(x, drs);
     }
 
+    static void checkAC2CVerifiableEncryptionException(final ApiException e) {
+        assertEquals("code", 400, e.getCode());
+        assertTrue("reason", e.getMessage().contains("specific_verify_decryption_ac2c : UNIMPLEMENTED"));
+        System.out.println("AC2C failed verify_decryption as expected");
+    }
     public void testVerifiableEncryptionAC2C_BBS() throws ApiException, IOException {
-        testVerifiableEncryptionAux(new X(TestData.AC2C_BBS, X.SigType.NonBlinded));
-        testVerifiableEncryptionAux(new X(TestData.AC2C_BBS, X.SigType.Blinded));
+        try {
+            testVerifiableEncryptionAux(new X(TestData.AC2C_BBS, X.SigType.NonBlinded));
+        } catch (ApiException e) {
+            checkAC2CVerifiableEncryptionException(e);
+        }
+        try {
+            testVerifiableEncryptionAux(new X(TestData.AC2C_BBS, X.SigType.Blinded));
+        } catch (ApiException e) {
+            checkAC2CVerifiableEncryptionException(e);
+        }
     }
     public void testVerifiableEncryptionAC2C_PS()  throws ApiException, IOException {
-        testVerifiableEncryptionAux(new X(TestData.AC2C_PS,  X.SigType.NonBlinded));
-        testVerifiableEncryptionAux(new X(TestData.AC2C_PS,  X.SigType.Blinded));
+        try {
+            testVerifiableEncryptionAux(new X(TestData.AC2C_PS,  X.SigType.NonBlinded));
+        } catch (ApiException e) {
+            checkAC2CVerifiableEncryptionException(e);
+        }
+        try {
+            testVerifiableEncryptionAux(new X(TestData.AC2C_PS,  X.SigType.Blinded));
+        } catch (ApiException e) {
+            checkAC2CVerifiableEncryptionException(e);
+        }
+    }
+    public void testVerifiableEncryptionAC2C()         throws ApiException, IOException {
+        testVerifiableEncryptionAC2C_BBS();
+        testVerifiableEncryptionAC2C_PS();
     }
     public void testVerifiableEncryptionDNC()      throws ApiException, IOException {
         testVerifiableEncryptionAux(new X(TestData.DNC,      X.SigType.NonBlinded));

--- a/src/vcp/zkp_backends/ac2c/authority.rs
+++ b/src/vcp/zkp_backends/ac2c/authority.rs
@@ -28,12 +28,8 @@ pub fn create_authority_data<S: ShortGroupSignatureScheme>() -> CreateAuthorityD
         let Issuer::<S> {verifiable_decryption_key, ..} = from_api(&signer_secret_data)?;
         Ok(AuthorityData::new(
             AuthorityPublicData(signer_public_setup_data.0),
-            to_api(verifiable_decryption_key)?,
-            // NOTE: this is the key for verifying correct decryption (e.g., by
-            // Governance Body), *not* for actual decryption.
-            // TODO-VERIFIABLE-ENCRYPTION: replace with real data if needed when AC2C supports verifying
-            // correct decryption
-            AuthorityDecryptionKey("BOGUS-SEE-TODO-VERIFIABLE-ENCRYPTION".to_string())))
+            AuthoritySecretData("BOGUS-AUTHORITY-DOES-NOT-SIGN-ANYTHING".to_string()),
+            to_api(verifiable_decryption_key)?))
     })
 }
 

--- a/tests/data/JSON/TestSequences/LicenseSubscription/LibrarySpecificOverrides/AC2C.json
+++ b/tests/data/JSON/TestSequences/LicenseSubscription/LibrarySpecificOverrides/AC2C.json
@@ -10,39 +10,27 @@
  {"contents": "AC2C panics if a requested Membership witness is not provided, which causes the test to fail; but the purpose of the test is to ensure that a prover cannot successfully create a proof without providing the necessary witness, which it can't, so we don't consider this behaviour to be a test failure",
   "tag": "Skip"},
 
- "020_encrypt_and_decrypt_one_attribute_and_verify":
- {"contents": "AC2C does not yet fully support verifiable encryption",
-  "tag": "Fail"},
-
- "021_encrypt_and_decrypt_one_attribute_request_decryption_first":
- {"contents": "AC2C does not yet fully support verifiable encryption",
-  "tag": "Fail"},
-
- "022_decrypt_one_attribute_but_not_encrypted_negative_test":
- {"contents": "AC2C does not yet fully support verifiable encryption",
-  "tag": "Fail"},
-
  "024_encrypt_and_decrypt_one_attribute_and_verify_decryption_correct_value":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"},
 
  "025_encrypt_and_decrypt_one_attribute_two_authorities_and_verify_decryption_correct_value":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"},
 
  "026_encrypt_and_decrypt_two_attributes_same_authority_and_verify_decryption_correct_values":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"},
 
  "027_encrypt_and_decrypt_two_attributes_different_authorities_and_verify_decryption_correct_values":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"},
 
  "038_SLOWSLOW_encrypt_and_decrypt_two_attributes_same_authority_and_verify_decryption_correct_values_multiple_equalities_strict_eq_eq":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"},
 
  "039_SLOWSLOW_encrypt_and_decrypt_two_attributes_same_authority_and_verify_decryption_correct_values_multiple_equalities_testbackend_eq_eq":
- {"contents": "AC2C does not yet fully support verifiable encryption",
+ {"contents": "AC2C does not yet fully support verifying decryption",
   "tag": "Fail"}
 }

--- a/tests/data/JSON/TestSequences/LicenseSubscription/json_test_019_SLOWSLOW_encrypt_and_decrypt_one_attribute_no_verification_yet.json
+++ b/tests/data/JSON/TestSequences/LicenseSubscription/json_test_019_SLOWSLOW_encrypt_and_decrypt_one_attribute_no_verification_yet.json
@@ -1,6 +1,6 @@
 {"comment": "this test does not create and verify the proof, just creates the requests",
  "descr": "SLOWSLOW_encrypt_and_decrypt_one_attribute_no_verification_yet",
- "provenance": "DO NOT MODIFY MANUALLY: this test was generated programatically; if you want to modify it, you can make a copy, and modify that.  For questions or suggestions about this test, file an issue at https://github.com/mark-moir/anoncreds-v2-rs -- and mention tag 2025-04-15",
+ "provenance": "DO NOT MODIFY MANUALLY: this test was generated programatically; if you want to modify it, you can make a copy, and modify that.  For questions or suggestions about this test, file an issue at https://github.com/mark-moir/anoncreds-v2-rs -- and mention tag 2025-04-21",
  "testseq": [{"contents": ["DMV",
                            ["CTText", "CTInt", "CTEncryptableText", "CTInt",
                             "CTAccumulatorMember"],
@@ -17,4 +17,7 @@
               "tag": "SignCredential"},
              {"contents": "Police", "tag": "CreateAuthority"},
              {"contents": ["Holder1", "DMV", 2, "Police"], "tag": "EncryptFor"},
-             {"contents": ["Holder1", "DMV", 2, "Police"], "tag": "Decrypt"}]}
+             {"contents": ["Holder1", "DMV", 2, "Police"], "tag": "Decrypt"},
+             {"contents": ["Holder1", "Strict",
+                           {"tag": "BothSucceedNoWarnings"}],
+              "tag": "CreateAndVerifyProof"}]}


### PR DESCRIPTION
This PR uses the capability implemented in https://github.com/hyperledger/anoncreds-v2-rs/pull/55 to enable decrypting verifiably encrypted attributes when a `CryptoInterface` is implemented using AC2C (the cryptography/ZKP library of [AnonCreds v2](https://github.com/hyperledger/anoncreds-v2-rs)).  This enables some tests that were previously overridden due to the lack of support for this feature to now pass.

AC2C does not yet support *verifying* decryption, which would enable a Governance Body that does not possess the decryption key (for example, a Court) to verify that the value decrypted by an Authority (e.g., Police) using the decryption key is the originally encrypted and signed value.  Therefore, some tests are still overridden, with the reason updated to indicate that it is specifically verifying decryption that is not yet implemented.

The main changes are in `src/vcp/zkp_backends/ac2c/proof.rs`.

This required fixing some cut-and-paste errors (in `src/vcp/zkp_backends/ac2c/presentation_request_setup.rs`) related to how credential labels are generated, which did not become apparent until we tried to decrypt encrypted values.

This PR also extends the REST server and the Java demo to exercise the new decryption support.

Finally, this PR also fixes an existing test that did not attempt to create and verify a proof after setting up its requirements.
