### PR TITLE
Verify disclosures consistent with Proof for AC2C backend, plus tests

### DIFF
--- a/src/vcp/zkp_backends/ac2c/presentation_request_setup.rs
+++ b/src/vcp/zkp_backends/ac2c/presentation_request_setup.rs
@@ -144,7 +144,7 @@ fn membership_label_for(c_lbl : &CredentialLabel, a_idx : &CredAttrIndex) -> Str
     format!("{MEMBERSHIP_PREFIX}{c_lbl}{a_idx}")
 }
 
-fn stmt_label_for(l: &CredentialLabel) -> String {
+pub(crate) fn stmt_label_for(l: &CredentialLabel) -> String {
     format!("{STMT_PREFIX}{l}")
 }
 

--- a/src/vcp/zkp_backends/ac2c/signer.rs
+++ b/src/vcp/zkp_backends/ac2c/signer.rs
@@ -200,7 +200,7 @@ pub fn create_schema_claims(
         .collect::<VCPResult<Vec<_>>>()
 }
 
-fn val_to_claim_data(
+pub fn val_to_claim_data(
     ct_dv : (&ClaimType, &DataValue)
 ) -> VCPResult<ClaimData>
 {


### PR DESCRIPTION
The first commit of this PR adds tests to confirm that incorrect values included in `DataForVerifier` cause verification to fail.  The failure of three of these tests confirms a bug in the way the VCP backend uses AC2C, identified by @rongcuid (thanks, good catch!).

The second commit fixes the bug by having the verifier check that the disclosed values in `DataForVerifier` are consistent with those in the `Presentation`.