### PR TITLE
Check disclosed indexes correct, test

### DIFF
--- a/src/vca/interfaces/types.rs
+++ b/src/vca/interfaces/types.rs
@@ -662,7 +662,7 @@ pub type OpaqueMaterial  = String;
 pub type RawIndex        = u64;
 pub type SharedParamKey  = String;
 
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum ProofMode {
     // Allow warnings when creating or verifying a proof
     Loose,

--- a/tests/vca/impl/general/presentation_request_setup_test.rs
+++ b/tests/vca/impl/general/presentation_request_setup_test.rs
@@ -84,6 +84,7 @@ mod spec {
                     td::D_CRED_LABEL.to_owned() => hashmap!(),
                     td::S_CRED_LABEL.to_owned() => hashmap!(),
                 ),
+                ProofMode::TestBackend
             )
             .unwrap();
 
@@ -207,7 +208,7 @@ mod spec {
 
         #[test]
         fn detects_and_rejects_an_equality_requirement_for_attributes_with_different_claimtypes() {
-            match presentation_request_setup(&PROOF_REQS, &SHARED, &REVEALS, &Strict) {
+            match presentation_request_setup(&PROOF_REQS, &SHARED, &REVEALS, Strict) {
                 Err(Error::General(t)) => {
                     let expected_strings: Vec<_> = vec!["multiple claim types",
                                                         "CTEncryptableText",

--- a/tests/vca/test_framework/steps.rs
+++ b/tests/vca/test_framework/steps.rs
@@ -3,6 +3,7 @@ use credx::str_vec_from;
 use credx::vca::{Error, VCAResult};
 use credx::vca::api;
 use credx::vca::r#impl::general::presentation_request_setup::get_proof_instructions;
+use credx::vca::r#impl::general::proof::{get_all_vals, get_vals_to_reveal};
 use credx::vca::r#impl::json::shared_params::put_shared_one;
 use credx::vca::r#impl::json::util::encode_to_text;
 use credx::vca::r#impl::util::*;
@@ -613,17 +614,10 @@ pub fn step_create_and_verify_proof(
             let all_wits: HashMap<IssuerLabelAsCredentialLabel,api::AllAccumulatorWitnesses> =
                 ts.accum_witnesses.get(&h_lbl).cloned().unwrap_or_default();
 
-            // We don't need to request revealing any attributes for getting ProofInstructions
-            // for InAccum requirements.
-            // But we do need to provide a map for each CredentialLabel
-            // because Proof.getValsToReveal uses mergeMaps and is therefore arguably too inflexible.
-            let to_reveal: HashMap<CredentialLabel,HashMap<CredAttrIndex,DataValue>> =
-                proof_reqs
-                .keys()
-                .map(|k| (k.clone(),HashMap::new()))
-                .collect();
+            let to_reveal = get_vals_to_reveal(
+                &get_all_vals(proof_reqs, all_sigs_and_rd)?);
 
-            let witness_reqs = get_proof_instructions(shared_params, proof_reqs, &to_reveal)?;
+            let witness_reqs = get_proof_instructions(shared_params, proof_reqs, &to_reveal, proof_mode)?;
 
             // collect all attributeIndex/sequenceNumber pairs,
             // together for each credential label


### PR DESCRIPTION
This PR adds checking at the "General" level that the disclosed attributes are for the requested indices. It also fixes tests that this broke and adds tests for the new checking.