### PR TITLE
Improve ordering of equality reqs, various paper-related changes

### DIFF
--- a/src/vca/impl/general/proof.rs
+++ b/src/vca/impl/general/proof.rs
@@ -22,12 +22,12 @@ pub fn create_proof(spec_prover: SpecificProver) -> CreateProof {
         move |pres_reqs, shared_params, sigs_and_rel_data_api, proof_mode, nonce| {
             let all_vals = get_all_vals(pres_reqs, sigs_and_rel_data_api)?;
             let vals_to_reveal = get_vals_to_reveal(&all_vals);
-            let (res_prf_insts, eq_reqs) = presentation_request_setup(
-                pres_reqs, shared_params, &vals_to_reveal, proof_mode)?;
             let warns_rev = validate_cred_reqs_against_schemas(
                 pres_reqs,
                 &get_schemas(shared_params, pres_reqs)?,
             )?;
+            let (res_prf_insts, eq_reqs) =
+                presentation_request_setup(pres_reqs, shared_params, &vals_to_reveal, proof_mode)?;
             if (proof_mode != ProofMode::TestBackend) {
                 validate_proof_instructions_against_values(&all_vals, &res_prf_insts)?;
                 eq_reqs.iter().try_for_each(|x| {validate_one_equality(&all_vals, x)})?;
@@ -49,7 +49,7 @@ pub fn create_proof(spec_prover: SpecificProver) -> CreateProof {
     )
 }
 
-pub fn validate_one_equality (
+fn validate_one_equality (
     all_vals: &HashMap<CredentialLabel,HashMap<CredAttrIndex,(DataValue,bool)>>,
     eq_req: &[(CredentialLabel, CredAttrIndex)]
 ) -> VCAResult<()> {

--- a/src/vca/zkp_backends/dnc/accumulators.rs
+++ b/src/vca/zkp_backends/dnc/accumulators.rs
@@ -34,12 +34,13 @@ pub fn create_accumulator_data() -> CreateAccumulatorData {
         let sp      = VbaSetupParams::<Bls12_381>::generate_using_rng(&mut rng);
         let kp      = VbaKeypair::<Bls12_381>::generate_using_rng(&mut rng, &sp);
         let pk      = &kp.public_key;
-        let ims : InMemoryState::<Fr> = InMemoryState::<Fr>::new();
         let acc     = PositiveAccumulator::initialize(&sp);
         let ad      = to_api_accumulator_data(&sp, &kp)?;
         #[cfg(not(feature="in_memory_state"))]
         let accumulator : api::Accumulator
                     = to_api(&acc)?;
+        #[cfg(feature="in_memory_state")]
+        let ims : InMemoryState::<Fr> = InMemoryState::<Fr>::new();
         #[cfg(feature="in_memory_state")]
         let accumulator : api::Accumulator
                     = to_api((&acc, &ims))?;
@@ -106,7 +107,6 @@ pub fn accumulator_add_remove() -> AccumulatorAddRemove {
             witnesses_for_new.insert(k.clone(), to_api(wit)?);
         }
         let witness_update_info : AccumulatorWitnessUpdateInfo = to_api( (o, afl, rfl) )?;
-        let accumulator_data      = to_api_accumulator_data(&sp, &kp)?;
         #[cfg(not(feature="in_memory_state"))]
         let accumulator           = to_api(&pa3)?;
         #[cfg(feature="in_memory_state")]

--- a/src/vca/zkp_backends/dnc/generate_frs.rs
+++ b/src/vca/zkp_backends/dnc/generate_frs.rs
@@ -37,7 +37,7 @@ pub fn generate_fr_from_val_and_ct(
     }
 }
 
-pub fn generate_frs_from_vals_and_ct(
+pub fn generate_frs_from_vals_and_cts(
     vals    : &[DataValue],
     sdcts   : &[ClaimType],
     err_msg : &str,

--- a/src/vca/zkp_backends/dnc/proof.rs
+++ b/src/vca/zkp_backends/dnc/proof.rs
@@ -219,7 +219,7 @@ fn add_statement_and_maybe_witness(
                     &cred_label, sigs, Error::General,
                     &["add_statement_and_maybe_witness".to_string(), "PoKofSig".to_string(),
                       "no signature for credential".to_string()])?;
-                let frs = generate_frs_from_vals_and_ct(vals, &schema, "add_statement_and_maybe_witness")?;
+                let frs = generate_frs_from_vals_and_cts(vals, &schema, "add_statement_and_maybe_witness")?;
                 add_pok_witness_new(witnesses, ((sig, frs), revealed_idxs_and_frs_for_cred));
             } else {
                 stmts.add(bbs_plus::PoKBBSSignatureG1Verifier::new_statement_from_params(*sig_pars, *pk, revealed));

--- a/src/vca/zkp_backends/dnc/reversible_encoding.rs
+++ b/src/vca/zkp_backends/dnc/reversible_encoding.rs
@@ -16,7 +16,7 @@ use zeroize::Zeroize;
 
 // see crypto-wasm/src/common.rs 56f4723103ab83b1cae23df3d013573c5c0ffb5d
 fn field_element_as_bytes(x : &mut Vec<u8>)
-    -> VCAResult<ark_ff::Fp<ark_ff::MontBackend<ark_bls12_381::FrConfig, 4>, 4>>
+    -> VCAResult<Fr>
 {
     let f = fr_from_uint8_array(x)?; // TODO true as argument
     let mut bytes = vec![];

--- a/src/vca/zkp_backends/dnc/signer.rs
+++ b/src/vca/zkp_backends/dnc/signer.rs
@@ -42,7 +42,7 @@ pub fn sign() -> SpecificSign {
         let sk : SecretKeyBls12_381 = from_api(signer_secret_data)?;
         let SignerPublicData { signer_public_setup_data, signer_public_schema, .. } = *signer_public_data.clone();
         let (sp, _) : (SignatureParamsG1::<Bls12_381>, PublicKeyG2<Bls12_381>) = from_api(&signer_public_setup_data)?;
-        let frs = generate_frs_from_vals_and_ct(vals, &signer_public_schema, "sign")?;
+        let frs = generate_frs_from_vals_and_cts(vals, &signer_public_schema, "sign")?;
         let mut rng = StdRng::seed_from_u64(rng_seed);
         let s = SignatureG1::<Bls12_381>::new(&mut rng, &frs, &sk, &sp)
             .map_err(|e| Error::General(format!("sign, {:?}", e)))?;


### PR DESCRIPTION
This PR consists of mostly minor changes made while preparing a paper about this work, including:
- renaming
- formatting
- commenting
- refactoring
- eliminating some warnings and some obsolete comments

Slightly more substantively, it also reorganises how equality requirements are "canonicalised" to ensure Provers and Verifiers agree on their order.  There is no functional change, just better code organisation.