### PR TITLE
Blind info correctness proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "itertools 0.12.1",
  "oblivious_transfer_protocols",
  "rayon",
@@ -630,7 +630,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "rayon",
  "serde",
  "serde_with",
@@ -811,7 +811,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "itertools 0.12.1",
  "rayon",
  "schnorr_pok",
@@ -995,6 +995,8 @@ dependencies = [
  "blsful",
  "bulletproofs-bls",
  "chrono",
+ "dock_crypto_utils 0.23.0",
+ "dock_merlin",
  "elliptic-curve",
  "elliptic-curve-tools 0.2.0",
  "env_logger",
@@ -1293,6 +1295,30 @@ dependencies = [
  "dock_merlin",
  "hkdf",
  "itertools 0.12.1",
+ "num",
+ "rayon",
+ "serde",
+ "serde_with",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "dock_crypto_utils"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4d284b7d0449d718e1740be2b1919f0f7da188c30f620ba74e7d33c070ad4d"
+dependencies = [
+ "aead",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "digest",
+ "dock_merlin",
+ "hkdf",
+ "itertools 0.14.0",
  "num",
  "rayon",
  "serde",
@@ -2124,6 +2150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,7 +2219,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "itertools 0.12.1",
  "rayon",
  "schnorr_pok",
@@ -2225,7 +2260,7 @@ dependencies = [
  "ark-serialize",
  "ark-snark",
  "ark-std",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "fnv",
  "log",
  "num-bigint",
@@ -2606,7 +2641,7 @@ dependencies = [
  "cc",
  "cipher",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "itertools 0.12.1",
  "rayon",
  "schnorr_pok",
@@ -2862,7 +2897,7 @@ dependencies = [
  "chacha20poly1305",
  "coconut-crypto",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "dock_merlin",
  "itertools 0.12.1",
  "kvac",
@@ -3395,7 +3430,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "dock_merlin",
  "legogroth16",
  "rayon",
@@ -3440,7 +3475,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "rayon",
  "serde",
  "serde_with",
@@ -3485,7 +3520,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "rayon",
  "schnorr_pok",
  "serde",
@@ -3698,7 +3733,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "oblivious_transfer_protocols",
  "rayon",
  "schnorr_pok",
@@ -3759,7 +3794,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "rayon",
  "schnorr_pok",
  "short_group_sig",
@@ -4361,7 +4396,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "kvac",
  "oblivious_transfer_protocols",
  "rayon",
@@ -4394,7 +4429,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "digest",
- "dock_crypto_utils",
+ "dock_crypto_utils 0.22.0",
  "itertools 0.12.1",
  "rayon",
  "secret_sharing_and_dkg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ zeroize = "1"
 # ----- docknetwork crypto
 bbs_plus = "0.24.0"
 legogroth16 = "0.17.0"
+dock_crypto_utils = "0.23.0"
+dock_merlin = "3.0.0"
 proof_system = "0.33.0"
 saver = "0.20.0"
 vb_accumulator = "0.28.0"

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,6 @@ fix-readme-markdown:
 	sed -i -e 's/<sub>/_/g'  $(README_MD)
 	sed -i -e 's/<\/sub>//g' $(README_MD)
 	sed -i -e 's/server\/README.md/server\/README.org/g' $(README_MD)
-	sed -i '1i<!--- DO NOT EDIT.  GENERATED FROM README.org --->' $(README_MD)
+	sed -i '' '1i\
+<!--- DO NOT EDIT. GENERATED FROM README.org --->\
+' $(README_MD)

--- a/TODO-plan.org
+++ b/TODO-plan.org
@@ -2,6 +2,9 @@
 
 * TODOs
 
+** BlindSigningCorrectnessProof related
+*** TODO src/vca/zkp_backends/dnc/signer.rs:63                 - abstraction fail?
+
 ** Security - must do
 *** DONE src/vca/zkp_backends/dnc/proof.rs:48                  - use real seed
       - let mut rng = StdRng::from_entropy();

--- a/src/vca/README.md
+++ b/src/vca/README.md
@@ -1,55 +1,56 @@
-<!--- DO NOT EDIT.  GENERATED FROM README.org --->
+<!--- DO NOT EDIT. GENERATED FROM README.org --->
+
 
 # Table of Contents
 
-1.  [Introduction](#orge81d445)
-2.  [Caveats](#orge440a8e)
-3.  [User abstraction](#orgeec1e9b)
-4.  [Running tests](#org3f80190)
-5.  [The test framework](#orgde0c45b)
-    1.  [JSON test file naming and contents](#org0543b0d)
-    2.  [Overview of test framework](#orgb9423de)
-    3.  [An example](#orgb1d1752)
-    4.  [TestSteps](#orgca66941)
-        1.  [CreateIssuer](#org7802df1)
-        2.  [CreateAccumulators](#orgc9616eb)
-        3.  [SignCredential](#orgc06bffb)
-        4.  [CreateBlindSigningInfo](#orgb5dcef8)
-        5.  [SignCredentialWithBlinding](#orgb0691a2)
-        6.  [AccumulatorAddRemove](#orgc31966c)
-        7.  [UpdateAccumulatorWitness](#orgc8e1fd6)
-        8.  [Reveal](#org1881a39)
-        9.  [InRange](#org9c59f44)
-        10. [InAccum](#org869fc3f)
-        11. [Equality](#org11416f7)
-        12. [CreateAndVerifyProof](#org3ed724b)
-        13. [CreateAuthority](#orgb18a0e6)
-        14. [EncryptFor](#org420dbb1)
-        15. [Decrypt](#orgf7daf62)
-        16. [VerifyDecryption](#orgdb7abf3)
-    5.  [Overriding tests](#org88d226a)
-    6.  [Test framework files](#orgd2ece7f)
-6.  [The VCA architecture](#orga429cef)
-    1.  [General](#org9ba7ded)
-    2.  [Specific](#orgda0bb66)
-7.  [Guide to `src/vca` code](#org260bbb3)
-    1.  [Directory structure](#org1462116)
-    2.  [Example of connecting a specific ZKP library to `VcaApi`](#orgf8c20e7)
-    3.  [Creating an Issuer's public and secret data (e.g., keys)](#org75f2af0)
-    4.  [Issuer signing a credential](#org144fc9c)
-    5.  [Unblinding a blinded signature](#org8976013)
-    6.  [Creating a proof](#org878dcfd)
-    7.  [Verifying a proof](#org0839c8b)
-    8.  [Proofs with revealed values](#orge8c3b21)
-    9.  [Proofs with range proofs](#org8cd0218)
-    10. [Proofs with verifiable encryption](#org4dabdb3)
-    11. [Proofs with equalities between attributes](#org79a27bc)
-    12. [Proofs with accumulators](#org4171918)
-    13. [Accumulator functions](#org30892fc)
+1.  [Introduction](#org30e0244)
+2.  [Caveats](#orgdbe393d)
+3.  [User abstraction](#orgfaa31ea)
+4.  [Running tests](#orgdd65cd2)
+5.  [The test framework](#org4336a22)
+    1.  [JSON test file naming and contents](#org2ac0262)
+    2.  [Overview of test framework](#org47e7167)
+    3.  [An example](#orgb3212e7)
+    4.  [TestSteps](#org18cae80)
+        1.  [CreateIssuer](#orga6fdf4c)
+        2.  [CreateAccumulators](#org23babad)
+        3.  [SignCredential](#org180a938)
+        4.  [CreateBlindSigningInfo](#orgad6a2d3)
+        5.  [SignCredentialWithBlinding](#org6b1ea2e)
+        6.  [AccumulatorAddRemove](#org87de202)
+        7.  [UpdateAccumulatorWitness](#orgd65eb8e)
+        8.  [Reveal](#org70beaac)
+        9.  [InRange](#org7558c93)
+        10. [InAccum](#orgf84724a)
+        11. [Equality](#org4e6ee00)
+        12. [CreateAndVerifyProof](#orgc3f983c)
+        13. [CreateAuthority](#orgde9212b)
+        14. [EncryptFor](#org3a5ac26)
+        15. [Decrypt](#orgc853d4a)
+        16. [VerifyDecryption](#orgbe1d5d5)
+    5.  [Overriding tests](#orgabbcfe6)
+    6.  [Test framework files](#orgf57a951)
+6.  [The VCA architecture](#orgab69c62)
+    1.  [General](#org777fb94)
+    2.  [Specific](#org160acd6)
+7.  [Guide to `src/vca` code](#org4ca8842)
+    1.  [Directory structure](#org0b2d2b5)
+    2.  [Example of connecting a specific ZKP library to `VcaApi`](#orgce2146b)
+    3.  [Creating an Issuer's public and secret data (e.g., keys)](#orga4eec49)
+    4.  [Issuer signing a credential](#org8f3adb8)
+    5.  [Unblinding a blinded signature](#org41649c7)
+    6.  [Creating a proof](#org80dede2)
+    7.  [Verifying a proof](#orgef8d6a8)
+    8.  [Proofs with revealed values](#org15ba81a)
+    9.  [Proofs with range proofs](#org8c5ede2)
+    10. [Proofs with verifiable encryption](#orgd2188c3)
+    11. [Proofs with equalities between attributes](#org75480d3)
+    12. [Proofs with accumulators](#org84e016f)
+    13. [Accumulator functions](#orgd11aa89)
 
 
 
-<a id="orge81d445"></a>
+<a id="org30e0244"></a>
 
 # Introduction
 
@@ -73,7 +74,7 @@ This work is by [Harold Carr](https://github.com/haroldcarr) and [Mark Moir](htt
 of the University of Maryland at College Park, during his Summer 2024 internship at Oracle Labs.
 
 
-<a id="orge440a8e"></a>
+<a id="orgdbe393d"></a>
 
 # Caveats
 
@@ -89,14 +90,13 @@ exploration.  In particular,
     Labs mentors at different times during their Rust learning process.  Therefore, different styles,
     tastes, and levels of expertise are evident in different parts of the code.  While we have made
     progress towards more consistent styles throughout, this is not complete.
--   There are quite a few TODOs, potentially including some that would undermine security if left
-    undone before this code were used in a practical application.
+-   Some TODOs remain
 -   While we hope to eventually contribute to [Hyperledger AnonCreds, v2](https://github.com/hyperledger/anoncreds-v2-rs) based on this work, we are not
     raising a Pull Request at this stage. Rather, we have made this work public in order to facilitate
     feedback and engagement towards something that we can offer as a contribution.
 
 
-<a id="orgeec1e9b"></a>
+<a id="orgfaa31ea"></a>
 
 # User abstraction
 
@@ -105,7 +105,7 @@ From an application/user perspective, our abstraction is defined by the
 
 -   By using the `implement_vca_api_using` function in [./api_utils.rs](./api_utils.rs) and providing an instance of
     `CryptoInterface`, such as `CRYPTO_INTERFACE_AC2C` (defined in [./zkp_backends/ac2c/crypto_interface.rs](./zkp_backends/ac2c/crypto_interface.rs)) and calling
-    its methods directly.  See [7.1](#org70c99f1) for more details.
+    its methods directly.  See [7.1](#org35244ca) for more details.
 -   By accessing the functionality via a Swagger/OpenAPI interface. We have built an HTTP/REST
     server serving such an interface.  See [../../server/README.org](../../server/README.org).
 -   Via our test framework, described below.  We recommend this approach as the easiest way to get
@@ -120,7 +120,7 @@ are less general, more historic, less well organised, etc.  We recommend focusin
 that are run by the test framework.
 
 
-<a id="org3f80190"></a>
+<a id="orgdd65cd2"></a>
 
 # Running tests
 
@@ -130,11 +130,11 @@ described in the next section.
 
 The [../../Makefile](../../Makefile) supports a number of `make` targets for running/skipping tests according to various
 criteria.  The two most important are `make test` and `make test-all`.  The former skips tests that are
-overridden to fail (see Section [5.4.16.3](#org77a4156)), so that unexpected failures are not masked by
+overridden to fail (see Section [5.4.16.3](#org3dc2645)), so that unexpected failures are not masked by
 those tests.  The latter runs these tests as well, so that the failures can be seen.
 
 
-<a id="orgde0c45b"></a>
+<a id="org4336a22"></a>
 
 # The test framework
 
@@ -166,7 +166,7 @@ handful of Makefile targets enable by using `cargo test` directly.  Here are som
     cargo test --features=ignore_slow_slow dnc::run_json_zkp_functionality_tests
 
 
-<a id="org0543b0d"></a>
+<a id="org2ac0262"></a>
 
 ## JSON test file naming and contents
 
@@ -193,7 +193,7 @@ to run only the test described in the next section:
     cargo test example_single_issuer_and_credential_in_accum_no_update
 
 
-<a id="orgb9423de"></a>
+<a id="org47e7167"></a>
 
 ## Overview of test framework
 
@@ -212,7 +212,7 @@ We make the simplifying assumption that each Holder can possess at most one cred
 each Issuer. This enables referring to credentials by the label of the Issuer that signed them.
 
 
-<a id="orgb1d1752"></a>
+<a id="orgb3212e7"></a>
 
 ## An example
 
@@ -263,7 +263,7 @@ as the one signed in the relevant credential, and (in examples involving decrypt
 decrypted values match the original signed values.
 
 
-<a id="orgca66941"></a>
+<a id="org18cae80"></a>
 
 ## TestSteps
 
@@ -275,7 +275,7 @@ enabling testing the behaviour of the underlying library with erroneous input th
 rejected by the "General" checks.
 
 
-<a id="org7802df1"></a>
+<a id="orga6fdf4c"></a>
 
 ### CreateIssuer
 
@@ -295,7 +295,7 @@ rejected by the "General" checks.
     -   `create_signer_data`
 
 
-<a id="orgc9616eb"></a>
+<a id="org23babad"></a>
 
 ### CreateAccumulators
 
@@ -312,7 +312,7 @@ rejected by the "General" checks.
     -   `create_accumulator_data` (once for each created accumulator)
 
 
-<a id="orgc06bffb"></a>
+<a id="org180a938"></a>
 
 ### SignCredential
 
@@ -341,7 +341,7 @@ rejected by the "General" checks.
     -   `sign`
 
 
-<a id="orgb5dcef8"></a>
+<a id="orgad6a2d3"></a>
 
 ### CreateBlindSigningInfo
 
@@ -363,7 +363,7 @@ rejected by the "General" checks.
     -   `create_blind_signing_info`
 
 
-<a id="orgb0691a2"></a>
+<a id="org6b1ea2e"></a>
 
 ### SignCredentialWithBlinding
 
@@ -393,7 +393,7 @@ rejected by the "General" checks.
     -   `unblind_blinded_signature`
 
 
-<a id="orgc31966c"></a>
+<a id="org87de202"></a>
 
 ### AccumulatorAddRemove
 
@@ -421,7 +421,7 @@ rejected by the "General" checks.
     -   `accumulator_add_remove`
 
 
-<a id="orgc8e1fd6"></a>
+<a id="orgd65eb8e"></a>
 
 ### UpdateAccumulatorWitness
 
@@ -464,7 +464,7 @@ rejected by the "General" checks.
     -   `update_accumulator_witness`, potentially multiple times as described above
 
 
-<a id="org1881a39"></a>
+<a id="org70beaac"></a>
 
 ### Reveal
 
@@ -489,7 +489,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="org9c59f44"></a>
+<a id="org7558c93"></a>
 
 ### InRange
 
@@ -527,7 +527,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="org869fc3f"></a>
+<a id="orgf84724a"></a>
 
 ### InAccum
 
@@ -551,7 +551,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="org11416f7"></a>
+<a id="org4e6ee00"></a>
 
 ### Equality
 
@@ -581,7 +581,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="org3ed724b"></a>
+<a id="orgc3f983c"></a>
 
 ### CreateAndVerifyProof
 
@@ -625,7 +625,7 @@ rejected by the "General" checks.
     -   `verify_proof`
 
 
-<a id="orgb18a0e6"></a>
+<a id="orgde9212b"></a>
 
 ### CreateAuthority
 
@@ -640,7 +640,7 @@ rejected by the "General" checks.
     -   `create_authority_data`
 
 
-<a id="org420dbb1"></a>
+<a id="org3a5ac26"></a>
 
 ### EncryptFor
 
@@ -662,7 +662,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="orgf7daf62"></a>
+<a id="orgc853d4a"></a>
 
 ### Decrypt
 
@@ -683,7 +683,7 @@ rejected by the "General" checks.
     -   none
 
 
-<a id="orgdb7abf3"></a>
+<a id="orgbe1d5d5"></a>
 
 ### VerifyDecryption
 
@@ -701,10 +701,10 @@ rejected by the "General" checks.
 
     -   `verify_decryption`
     
-    <a id="org77a4156"></a>
+    <a id="org3dc2645"></a>
 
 
-<a id="org88d226a"></a>
+<a id="orgabbcfe6"></a>
 
 ## Overriding tests
 
@@ -754,7 +754,7 @@ We would like to improve the override system.  In the meantime, it is documented
 [../../generate-tests-from-json/src/lib.rs](../../generate-tests-from-json/src/lib.rs).
 
 
-<a id="orgd2ece7f"></a>
+<a id="orgf57a951"></a>
 
 ## Test framework files
 
@@ -803,7 +803,7 @@ Located in [../../tests/vca/](../../tests/vca/):
 Note: the other tests located in [tests/vca](../../tests/vca) (various unit tests) can be ignored.
 
 
-<a id="orga429cef"></a>
+<a id="orgab69c62"></a>
 
 # The VCA architecture
 
@@ -853,7 +853,7 @@ VCA is comprised of three main parts
         verify) for a specific underlying ZKP library
 
 
-<a id="org9ba7ded"></a>
+<a id="org777fb94"></a>
 
 ## General
 
@@ -879,7 +879,7 @@ Both the general `create_proof` and `verify_proof` then pass that info to "speci
 create and verify.  The AC2C versions are shown in the above diagram.
 
 
-<a id="orgda0bb66"></a>
+<a id="org160acd6"></a>
 
 ## Specific
 
@@ -898,12 +898,12 @@ along with disclosed values.
 to verify the proof.
 
 
-<a id="org260bbb3"></a>
+<a id="org4ca8842"></a>
 
 # Guide to `src/vca` code
 
 
-<a id="org1462116"></a>
+<a id="org0b2d2b5"></a>
 
 ## Directory structure
 
@@ -1001,10 +1001,10 @@ The directory structure for the DNC implementation of `CryptoInterface` is:
     
             types.rs                      : Type aliases used in the DNC implementation
 
-<a id="org70c99f1"></a>
+<a id="org35244ca"></a>
 
 
-<a id="orgf8c20e7"></a>
+<a id="orgce2146b"></a>
 
 ## Example of connecting a specific ZKP library to `VcaApi`
 
@@ -1023,7 +1023,7 @@ An example of making this connection can be seen in the `run_json_test_ac2c` fun
 [../../tests/vca/zkp_functionality_tests/test_definitions.rs](../../tests/vca/zkp_functionality_tests/test_definitions.rs).
 
 
-<a id="org75f2af0"></a>
+<a id="orga4eec49"></a>
 
 ## Creating an Issuer's public and secret data (e.g., keys)
 
@@ -1039,7 +1039,7 @@ It takes
 -   a list of indices indicating which indices in the list of `ClaimType` are to have their values blinded
 
 Assuming the AC2C implementation of primitives are connected to `VcaApi`,
-as described in <a id="orgf13b265"></a>,
+as described in <a id="org3b4fdb2"></a>,
 then `create_signer_data` (in [./zkp_backends/ac2c/signer.rs](./zkp_backends/ac2c/signer.rs)) is invoked.
 
 The `create_signer_data` implementation
@@ -1059,7 +1059,7 @@ The `create_signer_data` implementation
 An Issuer would securely store the private data and make the public data available.
 
 
-<a id="org144fc9c"></a>
+<a id="org8f3adb8"></a>
 
 ## Issuer signing a credential
 
@@ -1097,8 +1097,18 @@ with
 `creater_blind_signing_data` returns `BlindInfoForSigner`
 (the commitment to the attribute values), which is given to `sign_with_blinded_attributes` (above).
 
-The AC2C implementation of `sign_with_blinded_attributes` is in [./zkp_backends/ac2c/signer.rs](./zkp_backends/ac2c/signer.rs).
+Note that ZKP backends must include in `BlindInfoForSigner` a proof of knowledge of the blinding
+factors used when committing to attribute values, which must be verified by the ZKP backend
+implementation of `sign_with_blinded_attributes`.  A possible future enhancement to VCA would be to
+explicitly surface these proofs in the API.  In that case, for example, an implementation of
+AnonCreds (v1) over VCA could populate the [Blinded Link Secret Correctness
+Proof](<https://anoncreds.github.io/anoncreds-spec/#the-blinded-link-secret-correctness-proof>) with
+such a proof.  Our prototype implementation of AnonCreds over VCA (not yet publicly available, but
+hopefully soon) populates it with dummy data to comply with the AnonCreds interface, knowing that
+the required proving and verifying is done by the ZKP backend in `create_blind_signing_info` and
+`sign_with_blinded_attributes`, respectively.
 
+The AC2C implementation of `sign_with_blinded_attributes` is in [./zkp_backends/ac2c/signer.rs](./zkp_backends/ac2c/signer.rs).
 The `sign_with_blinded_attributes` implementation
 
 -   converts each VCA non-blinded `DataValue` to an AC2C claim
@@ -1106,8 +1116,20 @@ The `sign_with_blinded_attributes` implementation
     and the secret data from `SignerData`
 -   returns a `BlindSignature` (an opaque representation of an AC2C `BlindCredentialBundle`)
 
+AC2C requires implementations of `BlindSignatureContext` to include a proof of knowledge of blinding
+factors, which is verified by `blind_sign`.  Thus the VCA backend for AC2C does not need to explicitly
+do so.
 
-<a id="org8976013"></a>
+The DNC implementation of `sign_with_blinded_attributes` in [./zkp_backends/dnc/signer.rs](./zkp_backends/ac2c/signer.rs) is
+similar to the one for AC2C, using DNC's types instead.  In contrast to AC2C, DNC's blind signing
+mechanism does not include proving and verifying knowledge of the blinding factors used
+(see comment [here](<https://github.com/docknetwork/crypto/blob/224f195bb8babc2d0de5256135120e0aca9fbd19/bbs_plus/src/signature.rs#L46>)).  For that
+reason, the DNC backend does so explicitly via `create_blind_info_correctness_proof`, which is called
+by `specific_create_blind_signing_info`, and `verify_blind_info_correctness_proof`, which is called
+by `specific_sign_with_blinded_attributes`.
+
+
+<a id="org41649c7"></a>
 
 ## Unblinding a blinded signature
 
@@ -1118,7 +1140,7 @@ to obtain a `Signature` ([./interfaces/types.rs](./interfaces/types.rs)), which 
 (specifically, the "proof-of-knowledge" of a signature).
 
 
-<a id="org878dcfd"></a>
+<a id="org80dede2"></a>
 
 ## Creating a proof
 
@@ -1173,7 +1195,7 @@ The AC2C `specific_prover` (named `specific_prover_ac2c` in [./zkp_backends/ac2c
 -   returns `DataForVerifier` that contains the VCA proof and any warnings
 
 
-<a id="org0839c8b"></a>
+<a id="orgef8d6a8"></a>
 
 ## Verifying a proof
 
@@ -1200,7 +1222,7 @@ converts the VCA information and data into formats used by AC2C, and then calls
 the AC2C `Presentation:verify` to verify the proof.
 
 
-<a id="orge8c3b21"></a>
+<a id="org15ba81a"></a>
 
 ## Proofs with revealed values
 
@@ -1256,7 +1278,7 @@ In the `specific_verifier_ac2c` case, it calls `anoncreds-v2-rs` `Presentation::
 the `PresentationSchema` to verify the proof.
 
 
-<a id="org8cd0218"></a>
+<a id="org8c5ede2"></a>
 
 ## Proofs with range proofs
 
@@ -1293,7 +1315,7 @@ which creates two `anoncreds-v2-rs` statements:
 Those statements are then used to create and verify proofs
 
 
-<a id="org4dabdb3"></a>
+<a id="orgd2188c3"></a>
 
 ## Proofs with verifiable encryption
 
@@ -1320,7 +1342,7 @@ which creates a `anoncreds-v2-rs` `VerifiableEncryptionStatement`
 NOTE: AC2C does not yet support decryption.
 
 
-<a id="org79a27bc"></a>
+<a id="org75480d3"></a>
 
 ## Proofs with equalities between attributes
 
@@ -1345,7 +1367,7 @@ where each `EqualityReq` is a list of pairs that point to values that should be 
 `EqualityStatement` for each equality.
 
 
-<a id="org4171918"></a>
+<a id="org84e016f"></a>
 
 ## Proofs with accumulators
 
@@ -1374,7 +1396,7 @@ The AC2C implementation then transforms that `ResolvedRequirement` into
 which creates a `anoncreds-v2-rs` `MembershipStatement`
 
 
-<a id="org30892fc"></a>
+<a id="orgd11aa89"></a>
 
 ## Accumulator functions
 

--- a/src/vca/README.org
+++ b/src/vca/README.org
@@ -852,13 +852,35 @@ with
 =creater_blind_signing_data= returns =BlindInfoForSigner=
 (the commitment to the attribute values), which is given to =sign_with_blinded_attributes= (above).
 
-The AC2C implementation of =sign_with_blinded_attributes= is in [[./zkp_backends/ac2c/signer.rs][./zkp_backends/ac2c/signer.rs]].
+Note that ZKP backends must include in =BlindInfoForSigner= a proof of knowledge of the blinding
+factors used when committing to attribute values, which must be verified by the ZKP backend
+implementation of =sign_with_blinded_attributes=.  A possible future enhancement to VCA would be to
+explicitly surface these proofs in the API.  In that case, for example, an implementation of
+AnonCreds (v1) over VCA could populate the [Blinded Link Secret Correctness
+Proof](https://anoncreds.github.io/anoncreds-spec/#the-blinded-link-secret-correctness-proof) with
+such a proof.  Our prototype implementation of AnonCreds over VCA (not yet publicly available, but
+hopefully soon) populates it with dummy data to comply with the AnonCreds interface, knowing that
+the required proving and verifying is done by the ZKP backend in =create_blind_signing_info= and
+=sign_with_blinded_attributes=, respectively.
 
+The AC2C implementation of =sign_with_blinded_attributes= is in [[./zkp_backends/ac2c/signer.rs][./zkp_backends/ac2c/signer.rs]].
 The =sign_with_blinded_attributes= implementation
 - converts each VCA non-blinded =DataValue= to an AC2C claim
 - uses AC2C's =blind_sign_credential=, providing the claims, the =BlindInfoForSigner=,
   and the secret data from =SignerData=
 - returns a =BlindSignature= (an opaque representation of an AC2C =BlindCredentialBundle=)
+
+AC2C requires implementations of =BlindSignatureContext= to include a proof of knowledge of blinding
+factors, which is verified by =blind_sign=.  Thus the VCA backend for AC2C does not need to explicitly
+do so.
+
+The DNC implementation of =sign_with_blinded_attributes= in [[./zkp_backends/ac2c/signer.rs][./zkp_backends/dnc/signer.rs]] is
+similar to the one for AC2C, using DNC's types instead.  In contrast to AC2C, DNC's blind signing
+mechanism does not include proving and verifying knowledge of the blinding factors used
+(see comment [here](https://github.com/docknetwork/crypto/blob/224f195bb8babc2d0de5256135120e0aca9fbd19/bbs_plus/src/signature.rs#L46)).  For that
+reason, the DNC backend does so explicitly via =create_blind_info_correctness_proof=, which is called
+by =specific_create_blind_signing_info=, and =verify_blind_info_correctness_proof=, which is called
+by =specific_sign_with_blinded_attributes=.
 
 # --------------------------------------------------
 ** Unblinding a blinded signature

--- a/src/vca/zkp_backends/ac2c/signer.rs
+++ b/src/vca/zkp_backends/ac2c/signer.rs
@@ -81,7 +81,8 @@ pub fn specific_create_blind_signing_info<S: ShortGroupSignatureScheme>()
             .map_err(|e| Error::General(ic_semi(&str_vec_from!("specific_create_blind_signing_info",
                                                                "BlindCredentialRequest::new",
                                                                format!("{e:?}")))))?;
-        // TODO: create and include PoK of blinder
+        // NOTE: it is not necessary to explicitly create a proof of knowledge of the
+        // blinders used; see comment in specific_sign_with_blinded_attributes below.
         Ok(BlindSigningInfo {blind_info_for_signer: to_api(blind_credential_request)?,
                              blinded_attributes: blind_attrs.to_vec(),
                              info_for_unblinding: to_api(blinder)?})
@@ -102,7 +103,14 @@ pub fn specific_sign_with_blinded_attributes<S: ShortGroupSignatureScheme>(
         let mut issuer : Issuer<S> = from_api(signer_secret_data)?;
         // cannot use get_location_and_backtrace_on_panic! (in its current form) here because
         // the type `&mut issuer::Issuer` may not be safely transferred across an unwind boundary
-        let sig = issuer.blind_sign_credential(&from_api(bifs)?, &claims)
+
+        // NOTE: it is not necessary to explicitly verify a proof of knowledge of the blinders used
+        // because it is included in BlindSignatureContext, which is included in
+        // BlindCredentialRequest.  The blind_sign_credential impls for both BBS and PS signature
+        // schemes verify this, as confirmed by the blind_sign_request_tamper_fails tests in
+        // tests/flow.rs.
+        let blind_credential_request: BlindCredentialRequest<S> = from_api(bifs)?;
+        let sig = issuer.blind_sign_credential(&blind_credential_request, &claims)
             .map_err(|e| convert_to_crypto_library_error("AC2C", "sign_with_blinded_attributes", e))?;
         to_api(sig)
     })

--- a/src/vca/zkp_backends/dnc/signer.rs
+++ b/src/vca/zkp_backends/dnc/signer.rs
@@ -13,8 +13,11 @@ use bbs_plus::prelude::PublicKeyG2;
 use bbs_plus::prelude::SecretKey;
 use bbs_plus::prelude::SignatureG1;
 use bbs_plus::prelude::SignatureParamsG1;
+use dock_crypto_utils::commitment::PedersenCommitmentKey;
+use dock_crypto_utils::transcript::{new_merlin_transcript, Transcript};
 // ------------------------------------------------------------------------------
 use ark_bls12_381::{Bls12_381, Fr, G1Affine};
+use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::field_hashers::{DefaultFieldHasher, HashToField};
 use ark_std::rand::SeedableRng;
 use ark_std::rand::rngs::StdRng;
@@ -50,6 +53,91 @@ pub fn sign() -> SpecificSign {
     })
 }
 
+// The following is modeled after similar functionality implemented for anoncreds here:
+//
+//   https://github.com/anoncreds/anoncreds-clsignatures-rs/blob/5c74d040e842c25d8e9a05ca65dee6fb277a9be0/src/prover.rs#L493
+//
+// to implement
+//
+//   https://anoncreds.github.io/anoncreds-spec/#the-blinded-link-secret-correctness-proof,
+//
+// which is what motivated this.  It therefore uses similar variable names for clarity VCA does not
+// yet support committing to attributes, so only hidden blinded messages are supported here so far.
+
+// TODO: This is a somewhat of an abstraction fail because it depends on knowing how the commitment
+// was created, which is done in the bbs_plus crate.  Perhaps it should be in bbs_plus, rather than
+// being left to the Issuer (see this comment:
+//
+//   https://github.com/docknetwork/crypto/blob/224f195bb8babc2d0de5256135120e0aca9fbd19/bbs_plus/src/signature.rs#L46
+
+/// Create a proof of knowledge of the blinder used to blind some messages.
+fn create_blind_info_correctness_proof(
+    spsd: &SignerPublicSetupData,
+    messages: &[(usize, &Fr)],
+    v_prime_blinder: &Fr,
+    u_commitment: &G1Affine,
+) -> VCAResult<BlindInfoCorrectnessProof> {
+    let (sp, _): (SignatureParamsG1<Bls12_381>, PublicKeyG2<Bls12_381>) = from_api(spsd)?;
+    // Sort messages by index for deterministic ordering
+    let mut msgs = messages.to_vec();
+    msgs.sort_by_key(|(idx, _)| *idx);
+
+    // Randomness
+    let mut rng = StdRng::from_entropy();
+    let v_dash_tilde = Fr::rand(&mut rng);
+    let m_tildes: Vec<Fr> = msgs.iter().map(|_| Fr::rand(&mut rng)).collect();
+
+    // Commitment to randomness
+    let mut u_tilde_proj = sp.h_0 * v_dash_tilde;
+    for ((idx, _), m_tilde_i) in msgs.iter().zip(m_tildes.iter()) {
+        u_tilde_proj += sp.h[*idx] * m_tilde_i;
+    }
+    let u_tilde = u_tilde_proj.into_affine();
+
+    // Fiat-Shamir challenge
+    let challenge =
+        generate_challenge_for_blinding_info_correctness_proof(&sp, u_commitment, &u_tilde);
+
+    // Responses
+    let v_dash_cap = challenge * v_prime_blinder + v_dash_tilde;
+    let m_caps: Vec<(usize, Fr)> = msgs
+        .iter()
+        .zip(m_tildes.iter())
+        .map(|((idx, value), m_tilde)| (*idx, *m_tilde + challenge * *value))
+        .collect();
+
+    Ok(BlindInfoCorrectnessProof {
+        u_tilde,
+        v_dash_cap,
+        m_caps,
+    })
+}
+
+// The following is modeled after similar functionality implemented for anoncreds here:
+//   https://github.com/anoncreds/anoncreds-clsignatures-rs/blob/5c74d040e842c25d8e9a05ca65dee6fb277a9be0/src/issuer.rs#L1018
+// See comment above for create_blinding_info_correctness_proof.
+/// Verify a proof of knowledge of the blinder used to blind some messages.
+fn verify_blind_info_correctness_proof(
+    sp: &SignatureParamsG1<Bls12_381>,
+    u_commitment: &G1Affine,
+    proof: &BlindInfoCorrectnessProof,
+) -> VCAResult<()> {
+    let challenge =
+        generate_challenge_for_blinding_info_correctness_proof(sp, u_commitment, &proof.u_tilde);
+
+    let u_cap = proof.m_caps.iter().fold(
+        -(*u_commitment * challenge) + sp.h_0 * proof.v_dash_cap,
+        |acc, (idx, m_cap)| acc + sp.h[*idx] * m_cap,
+    );
+
+    if u_cap != proof.u_tilde {
+        return(Err(Error::General(
+            "blind info proof verification failed".to_string()
+        )))
+    };
+    Ok(())
+}
+
 pub fn specific_create_blind_signing_info() -> SpecificCreateBlindSigningInfo {
     Arc::new(|rng_seed, spsd, schema, blind_attrs| {
         let (sp, _) = from_api(spsd)?;
@@ -61,15 +149,25 @@ pub fn specific_create_blind_signing_info() -> SpecificCreateBlindSigningInfo {
             .iter()
             .map(|(x,y)| (*x,y))
             .collect::<Vec<(usize,&Fr)>>();
-        let blind_credential_commitment = sp.commit_to_messages(committed_messages, &blinder)
+        let blinding_info = sp.commit_to_messages(committed_messages.clone(), &blinder)
             .map_err(|e| Error::General(ic_semi(&str_vec_from!(
                 "specific_create_blind_signing_info", format!("{e:?}")))))?;
-        // TODO: create and include PoK of blinder
-        let blind_info_for_signer = to_api(blind_credential_commitment)?;
+        // Create and include PoK of blinder
+        let blinding_info_correctness_proof = create_blind_info_correctness_proof(
+            spsd,
+            committed_messages.as_slice(),
+            &blinder,
+            &blinding_info,
+        )?;
+        let payload = BlindInfoForSignerPayload {
+            blinding_info,
+            blinding_info_correctness_proof,
+        };
         Ok(BlindSigningInfo {
-            blind_info_for_signer,
+            blind_info_for_signer: to_api(payload)?,
             blinded_attributes: blind_attrs.to_vec(),
-            info_for_unblinding: to_api(blinder)?})
+            info_for_unblinding: to_api(blinder)?,
+        })
     })
 }
 
@@ -85,9 +183,20 @@ pub fn specific_sign_with_blinded_attributes() -> SpecificSignWithBlindedAttribu
             .iter()
             .map(|(x,y)| (*x,y))
             .collect::<BTreeMap<usize,&Fr>>();
-        let commitment: G1Affine = from_api(bifs)?;
+
+        let BlindInfoForSignerPayload {
+            blinding_info,
+            blinding_info_correctness_proof,
+        } = from_api(bifs)?;
+
+        verify_blind_info_correctness_proof(
+            &sp,
+            &blinding_info,
+            &blinding_info_correctness_proof,
+        )?;
+
         let sig = SignatureG1::<Bls12_381>::new_with_committed_messages(
-            &mut rng, &commitment, uncommitted_messages, &sk, &sp)
+            &mut rng, &blinding_info, uncommitted_messages, &sk, &sp)
             .map_err(|e| Error::General(ic_semi(&str_vec_from!(
                 "specific_sign_with_blinded_attributes",
                 format!("{e:?}")))))?;
@@ -127,5 +236,17 @@ fn create_index_fr_pairs(s: &str,
         .collect::<Vec<VCAResult<(usize,Fr)>>>()
         .into_iter()
         .collect::<VCAResult<Vec<(usize,Fr)>>>()
+}
+
+fn generate_challenge_for_blinding_info_correctness_proof(
+    sp: &SignatureParamsG1<Bls12_381>,
+    u_commitment: &G1Affine,
+    u_tilde: &G1Affine,
+) -> Fr {
+    let mut transcript = new_merlin_transcript(b"dnc_blind_info_correctness");
+    transcript.append(b"signature params", sp);
+    transcript.append(b"commitment to messages", u_commitment);
+    transcript.append(b"commitment to randomness", u_tilde);
+    transcript.challenge_scalar(b"challenge")
 }
 

--- a/src/vca/zkp_backends/dnc/to_from_api/signer_to_from_api.rs
+++ b/src/vca/zkp_backends/dnc/to_from_api/signer_to_from_api.rs
@@ -4,6 +4,7 @@ use crate::vca::r#impl::to_from_api::*;
 use crate::{impl_vca_roundtrip_json, impl_vca_roundtrip_ark};
 use crate::vca::interfaces::types as api;
 use crate::vca::zkp_backends::dnc::types::*;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 // ------------------------------------------------------------------------------
 use bbs_plus::prelude::KeypairG2;
 use bbs_plus::prelude::PublicKeyG2;
@@ -13,7 +14,6 @@ use bbs_plus::prelude::SignatureParamsG1;
 // ------------------------------------------------------------------------------
 use ark_bls12_381::{Bls12_381, Fr, G1Affine};
 use ark_ec::pairing::Pairing;
-use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 // ------------------------------------------------------------------------------
 
 // ------------------------------------------------------------------------------
@@ -68,6 +68,10 @@ impl VcaTryFrom<&api::Signature> for SignatureG1::<Bls12_381> {
 // ------------------------------------------------------------------------------
 
 impl_vca_roundtrip_ark!(G1Affine => api::BlindInfoForSigner);
+
+// ------------------------------------------------------------------------------
+
+impl_vca_roundtrip_ark!(BlindInfoForSignerPayload => api::BlindInfoForSigner);
 
 // ------------------------------------------------------------------------------
 

--- a/src/vca/zkp_backends/dnc/types.rs
+++ b/src/vca/zkp_backends/dnc/types.rs
@@ -10,8 +10,9 @@ use proof_system::prelude::Proof;
 use saver::prelude::*;
 use vb_accumulator::prelude::MembershipWitness;
 // ------------------------------------------------------------------------------
-use ark_bls12_381::{Bls12_381,G1Affine};
+use ark_bls12_381::{Bls12_381, Fr, G1Affine};
 use ark_ec::pairing::Pairing;
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 // ------------------------------------------------------------------------------
 use serde::*;
 use std::collections::HashMap;
@@ -36,3 +37,17 @@ pub struct AuthorityPublicSetupData {
     pub snark_proving_key : saver::saver_groth16::ProvingKey::<Bls12_381>,
 }
 
+#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
+pub struct BlindInfoCorrectnessProof {
+    pub u_tilde: G1Affine,
+    pub v_dash_cap: Fr,
+    pub m_caps: Vec<(usize, Fr)>,
+}
+
+#[derive(CanonicalSerialize, CanonicalDeserialize, Clone, Debug)]
+pub struct BlindInfoForSignerPayload {
+    pub blinding_info: G1Affine,
+    pub blinding_info_correctness_proof: BlindInfoCorrectnessProof,
+}
+
+// ------------------------------------------------------------------------------

--- a/tests/vca/zkp_functionality_tests/blind_signing.rs
+++ b/tests/vca/zkp_functionality_tests/blind_signing.rs
@@ -1,4 +1,3 @@
-use ark_bls12_381::{G1Affine as DncBlindInfo, G1Projective};
 use blsful::inner_types::Scalar as BlsScalar;
 use credx::blind::BlindCredentialRequest;
 use credx::knox::bbs::BbsScheme;
@@ -10,12 +9,11 @@ use credx::vca::r#impl::to_from_api::{from_api, to_api};
 use credx::vca::types as api;
 use credx::vca::VCAResult;
 use credx::vca::Error;
-use ark_ec::{AffineRepr, CurveGroup, Group};
 use credx::vca::zkp_backends::ac2c::crypto_interface::{
     CRYPTO_INTERFACE_AC2C_BBS, CRYPTO_INTERFACE_AC2C_PS,
 };
 use credx::vca::zkp_backends::dnc::crypto_interface::CRYPTO_INTERFACE_DNC;
-
+use credx::vca::zkp_backends::dnc::types::BlindInfoForSignerPayload as DncBlindInfo;
 
 // Simple fixtures for a single-blinded attribute schema.
 fn schema() -> Vec<api::ClaimType> {
@@ -85,8 +83,6 @@ fn build_blind_infos(
 
 fn do_not_tamper<T>(g: T, _a: T) -> T { g }
 
-fn alternative_tamper<T>(_g: T, a: T) -> T { a }
-
 fn ac2c_tamper_commitment<S: Clone + ShortGroupSignatureScheme>(
     good: BlindCredentialRequest<S>,
     alt: BlindCredentialRequest<S>,
@@ -123,14 +119,23 @@ fn ac2c_tamper_proof_ps(
     good
 }
 
-fn any_failure_will_do(_e: &Error) -> bool {
-    true
+fn dnc_tamper_commitment(good: DncBlindInfo, alt: DncBlindInfo) -> DncBlindInfo {
+    let mut tampered = good;
+    tampered.blinding_info = alt.blinding_info;
+    tampered.blinding_info_correctness_proof.u_tilde = alt.blinding_info;
+    tampered
 }
 
 fn dnc_tamper_proof(good: DncBlindInfo, _alt: DncBlindInfo) -> DncBlindInfo {
-    let mut g1: G1Projective = good.into_group();
-    g1 += G1Projective::generator();
-    g1.into_affine()
+    let mut tampered = good;
+    let (_, mcap) = tampered
+        .blinding_info_correctness_proof
+        .m_caps
+        .get_mut(0)
+        .expect("expected at least one m_cap entry");
+    // Mutate the first scalar; add a small constant
+    *mcap += ark_bls12_381::Fr::from(3u128);
+    tampered
 }
 
 fn expect_invalid_signing(e: &Error) -> bool {
@@ -239,7 +244,6 @@ macro_rules! gen_tests {
 gen_tests!(
     ac2c_bbs, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, do_not_tamper, from_api_ac2c_bbs, to_api_ac2c_bbs, None;
     ac2c_ps,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  do_not_tamper, from_api_ac2c_ps,  to_api_ac2c_ps,  None;
-    // Now dnc_tamper (below) passes, but the happy path test here fails because the concrete type associated with BlindInfoforSigner by DNC has changed
     dnc,      &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      do_not_tamper, from_api_dnc,      to_api_dnc,      None;
 );
 
@@ -249,5 +253,6 @@ gen_tests!(
     ac2c_bbs_tamper_proof, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, ac2c_tamper_proof_bbs,  from_api_ac2c_bbs, to_api_ac2c_bbs, Some(expect_invalid_signing);
     ac2c_ps_tamper,        &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_commitment, from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
     ac2c_ps_tamper_proof,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_proof_ps,   from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
-    dnc_tamper,            &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      alternative_tamper,     from_api_dnc,      to_api_dnc,      Some(any_failure_will_do);
+    dnc_tamper      ,      &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      dnc_tamper_commitment,  from_api_dnc,      to_api_dnc,      Some(expect_blind_info_failure);
+    dnc_tamper_proof,      &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      dnc_tamper_proof,       from_api_dnc,      to_api_dnc,      Some(expect_blind_info_failure);
 );

--- a/tests/vca/zkp_functionality_tests/blind_signing.rs
+++ b/tests/vca/zkp_functionality_tests/blind_signing.rs
@@ -1,0 +1,254 @@
+use ark_bls12_381::G1Affine as DncBlindInfo;
+use blsful::inner_types::Scalar as BlsScalar;
+use credx::blind::BlindCredentialRequest;
+use credx::knox::bbs::BbsScheme;
+use credx::knox::ps::PsScheme;
+use credx::knox::short_group_sig_core::short_group_traits::ShortGroupSignatureScheme;
+use credx::vca::api::VcaApi;
+use credx::vca::api_utils::implement_vca_api_using;
+use credx::vca::r#impl::to_from_api::{from_api, to_api};
+use credx::vca::types as api;
+use credx::vca::VCAResult;
+use credx::vca::Error;
+use ark_bls12_381::{G1Affine, G1Projective};
+use ark_ec::{AffineRepr, CurveGroup, Group};
+use credx::vca::zkp_backends::ac2c::crypto_interface::{
+    CRYPTO_INTERFACE_AC2C_BBS, CRYPTO_INTERFACE_AC2C_PS,
+};
+use credx::vca::zkp_backends::dnc::crypto_interface::CRYPTO_INTERFACE_DNC;
+
+
+// Simple fixtures for a single-blinded attribute schema.
+fn schema() -> Vec<api::ClaimType> {
+    vec![
+        api::ClaimType::CTText,
+        api::ClaimType::CTInt,                 // blinded
+        api::ClaimType::CTText,
+        api::ClaimType::CTInt,
+        api::ClaimType::CTAccumulatorMember,
+    ]
+}
+
+fn blinded_idx() -> Vec<api::CredAttrIndex> {
+    vec![1]
+}
+
+fn blinded_vals_good() -> Vec<api::CredAttrIndexAndDataValue> {
+    vec![api::CredAttrIndexAndDataValue {
+        index: 1,
+        value: api::DataValue::DVInt(42),
+    }]
+}
+
+fn blinded_vals_alt() -> Vec<api::CredAttrIndexAndDataValue> {
+    vec![api::CredAttrIndexAndDataValue {
+        index: 1,
+        value: api::DataValue::DVInt(7),
+    }]
+}
+
+fn non_blinded_vals() -> Vec<api::CredAttrIndexAndDataValue> {
+    vec![
+        (0, api::DataValue::DVText("meta".to_string())),
+        (2, api::DataValue::DVText("ssn".to_string())),
+        (3, api::DataValue::DVInt(180)),
+        (4, api::DataValue::DVText("abcdef0123456789abcdef0123456789".to_string())),
+    ]
+    .into_iter()
+    .map(|(i, v)| api::CredAttrIndexAndDataValue { index: i, value: v })
+    .collect()
+}
+
+fn build_blind_infos(
+    api: &VcaApi,
+) -> VCAResult<(
+    api::BlindSigningInfo,
+    api::BlindSigningInfo,
+    api::SignerData,
+    Vec<api::CredAttrIndexAndDataValue>,
+    Vec<api::ClaimType>,
+)> {
+    let create_signer_data = api.create_signer_data.clone();
+    let create_blind_info = api.create_blind_signing_info.clone();
+
+    let schema = schema();
+    let blinded_idx = blinded_idx();
+    let non_blinded = non_blinded_vals();
+
+    let sd = create_signer_data(0, &schema, &blinded_idx, api::ProofMode::TestBackend)?;
+    let bsi_good =
+        create_blind_info(0, &sd.signer_public_data, &blinded_vals_good(), api::ProofMode::TestBackend)?;
+    let bsi_alt =
+        create_blind_info(0, &sd.signer_public_data, &blinded_vals_alt(), api::ProofMode::TestBackend)?;
+
+    Ok((bsi_good, bsi_alt, sd, non_blinded, schema))
+}
+
+fn do_not_tamper<T>(g: T, _a: T) -> T { g }
+
+fn alternative_tamper<T>(_g: T, a: T) -> T { a }
+
+fn ac2c_tamper_commitment<S: Clone + ShortGroupSignatureScheme>(
+    good: BlindCredentialRequest<S>,
+    alt: BlindCredentialRequest<S>,
+) -> BlindCredentialRequest<S> {
+    let mut tampered = good;
+    tampered.blind_signature_context = alt.blind_signature_context;
+    tampered
+}
+
+fn ac2c_tamper_proof_bbs(
+    mut good: BlindCredentialRequest<BbsScheme>,
+    _alt: BlindCredentialRequest<BbsScheme>,
+) -> BlindCredentialRequest<BbsScheme> {
+    // Must actually alter proof data; fall back to alt if not enough proofs.
+    let p = good
+        .blind_signature_context
+        .proofs
+        .get_mut(0)
+        .expect("expected at least one proof scalar");
+    *p = BlsScalar::from_okm(&[1u8; 48]);
+    good
+}
+
+fn ac2c_tamper_proof_ps(
+    mut good: BlindCredentialRequest<PsScheme>,
+    _alt: BlindCredentialRequest<PsScheme>,
+) -> BlindCredentialRequest<PsScheme> {
+    let p = good
+        .blind_signature_context
+        .proofs
+        .get_mut(0)
+        .expect("expected at least one proof scalar");
+    *p = BlsScalar::from_okm(&[2u8; 48]);
+    good
+}
+
+fn any_failure_will_do(_e: &Error) -> bool {
+    true
+}
+
+fn dnc_tamper_proof(good: DncBlindInfo, _alt: DncBlindInfo) -> DncBlindInfo {
+    let mut g1: G1Projective = good.into_group();
+    g1 += G1Projective::generator();
+    g1.into_affine()
+}
+
+fn expect_invalid_signing(e: &Error) -> bool {
+    format!("{e:?}").contains("InvalidSigningOperation")
+}
+
+fn expect_blind_info_failure(e: &Error) -> bool {
+    format!("{e:?}").contains("blind info proof verification failed")
+}
+
+fn run_blind_sign(
+    api: VcaApi,
+    bifs_builder: impl FnOnce(&api::BlindSigningInfo, &api::BlindSigningInfo) -> VCAResult<api::BlindInfoForSigner>,
+) -> VCAResult<()> {
+    let (bsi_good, bsi_alt, signer_data, non_blinded, schema) = build_blind_infos(&api)?;
+    let blind_info_for_signer = bifs_builder(&bsi_good, &bsi_alt)?;
+
+    let blinded_sig = (api.sign_with_blinded_attributes.clone())(
+        0,
+        &non_blinded,
+        &blind_info_for_signer,
+        &signer_data,
+        api::ProofMode::TestBackend,
+    )?;
+    (api.unblind_blinded_signature.clone())(
+        &schema,
+        &bsi_good.blinded_attributes,
+        &blinded_sig,
+        &bsi_good.info_for_unblinding,
+        api::ProofMode::TestBackend,
+    )?;
+
+    Ok(())
+}
+
+fn run_blind_sign_roundtrip<T: Clone>(
+    api: VcaApi,
+    tamper: impl Fn(T, T) -> T,
+    from_api_fn: fn(&api::BlindInfoForSigner) -> VCAResult<T>,
+    to_api_fn: fn(T) -> VCAResult<api::BlindInfoForSigner>,
+) -> VCAResult<()> {
+    run_blind_sign(api, |good, alt| {
+        let payload_good = from_api_fn(&good.blind_info_for_signer)?;
+        let payload_alt = from_api_fn(&alt.blind_info_for_signer)?;
+        let payload_use = tamper(payload_good, payload_alt);
+        to_api_fn(payload_use)
+    })
+}
+
+fn from_api_ac2c_bbs(
+    bi: &api::BlindInfoForSigner,
+) -> VCAResult<BlindCredentialRequest<BbsScheme>> {
+    from_api(bi)
+}
+fn to_api_ac2c_bbs(
+    payload: BlindCredentialRequest<BbsScheme>,
+) -> VCAResult<api::BlindInfoForSigner> {
+    to_api(payload)
+}
+
+fn from_api_ac2c_ps(
+    bi: &api::BlindInfoForSigner,
+) -> VCAResult<BlindCredentialRequest<PsScheme>> {
+    from_api(bi)
+}
+fn to_api_ac2c_ps(
+    payload: BlindCredentialRequest<PsScheme>,
+) -> VCAResult<api::BlindInfoForSigner> {
+    to_api(payload)
+}
+
+fn from_api_dnc(bi: &api::BlindInfoForSigner) -> VCAResult<DncBlindInfo> {
+    from_api(bi)
+}
+fn to_api_dnc(payload: DncBlindInfo) -> VCAResult<api::BlindInfoForSigner> {
+    to_api(payload)
+}
+
+macro_rules! gen_tests {
+    ($($modname:ident, $crypto:expr, $payload_ty:ty, $tamper:expr, $from_api_fn:expr, $to_api_fn:expr, $expect:expr);+ $(;)?) => {
+        $(mod $modname {
+            use super::*;
+            #[test]
+            fn blind_sign_roundtrip_ok() {
+                let api = implement_vca_api_using($crypto);
+                let expect: Option<fn(&Error) -> bool> = $expect;
+                let res = run_blind_sign_roundtrip::<$payload_ty>(
+                    api,
+                    $tamper,
+                    $from_api_fn,
+                    $to_api_fn,
+                );
+                match expect {
+                    None => assert!(res.is_ok(), "{res:?}"),
+                    Some(pred) => match res {
+                        Ok(_) => panic!("expected error, got success"),
+                        Err(e) => assert!(pred(&e), "unexpected error: {e:?}"),
+                    },
+                }
+            }
+        })+
+    };
+}
+
+// Generate happy-path tests for each backend; no tampering.
+gen_tests!(
+    ac2c_bbs, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, do_not_tamper, from_api_ac2c_bbs, to_api_ac2c_bbs, None;
+    ac2c_ps,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  do_not_tamper, from_api_ac2c_ps,  to_api_ac2c_ps,  None;
+    dnc,      &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      do_not_tamper, from_api_dnc,      to_api_dnc,      None;
+);
+
+// Generate tamper tests expecting an error.
+gen_tests!(
+    ac2c_bbs_tamper,       &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, ac2c_tamper_commitment, from_api_ac2c_bbs, to_api_ac2c_bbs, Some(expect_invalid_signing);
+    ac2c_bbs_tamper_proof, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, ac2c_tamper_proof_bbs,  from_api_ac2c_bbs, to_api_ac2c_bbs, Some(expect_invalid_signing);
+    ac2c_ps_tamper,        &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_commitment, from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
+    ac2c_ps_tamper_proof,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_proof_ps,   from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
+    // Try replacing the commitment with an alternative one, accept any failure.  Test fails because DNC does not create/verify proof of knowledge of blinder, so signing succeeds.
+    dnc_tamper,            &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      alternative_tamper,     from_api_dnc,      to_api_dnc,      Some(any_failure_will_do);
+);

--- a/tests/vca/zkp_functionality_tests/blind_signing.rs
+++ b/tests/vca/zkp_functionality_tests/blind_signing.rs
@@ -1,4 +1,4 @@
-use ark_bls12_381::G1Affine as DncBlindInfo;
+use ark_bls12_381::{G1Affine as DncBlindInfo, G1Projective};
 use blsful::inner_types::Scalar as BlsScalar;
 use credx::blind::BlindCredentialRequest;
 use credx::knox::bbs::BbsScheme;
@@ -10,7 +10,6 @@ use credx::vca::r#impl::to_from_api::{from_api, to_api};
 use credx::vca::types as api;
 use credx::vca::VCAResult;
 use credx::vca::Error;
-use ark_bls12_381::{G1Affine, G1Projective};
 use ark_ec::{AffineRepr, CurveGroup, Group};
 use credx::vca::zkp_backends::ac2c::crypto_interface::{
     CRYPTO_INTERFACE_AC2C_BBS, CRYPTO_INTERFACE_AC2C_PS,
@@ -240,6 +239,7 @@ macro_rules! gen_tests {
 gen_tests!(
     ac2c_bbs, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, do_not_tamper, from_api_ac2c_bbs, to_api_ac2c_bbs, None;
     ac2c_ps,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  do_not_tamper, from_api_ac2c_ps,  to_api_ac2c_ps,  None;
+    // Now dnc_tamper (below) passes, but the happy path test here fails because the concrete type associated with BlindInfoforSigner by DNC has changed
     dnc,      &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      do_not_tamper, from_api_dnc,      to_api_dnc,      None;
 );
 
@@ -249,6 +249,5 @@ gen_tests!(
     ac2c_bbs_tamper_proof, &CRYPTO_INTERFACE_AC2C_BBS, BlindCredentialRequest<BbsScheme>, ac2c_tamper_proof_bbs,  from_api_ac2c_bbs, to_api_ac2c_bbs, Some(expect_invalid_signing);
     ac2c_ps_tamper,        &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_commitment, from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
     ac2c_ps_tamper_proof,  &CRYPTO_INTERFACE_AC2C_PS,  BlindCredentialRequest<PsScheme>,  ac2c_tamper_proof_ps,   from_api_ac2c_ps,  to_api_ac2c_ps,  Some(expect_invalid_signing);
-    // Try replacing the commitment with an alternative one, accept any failure.  Test fails because DNC does not create/verify proof of knowledge of blinder, so signing succeeds.
     dnc_tamper,            &CRYPTO_INTERFACE_DNC,      DncBlindInfo,                      alternative_tamper,     from_api_dnc,      to_api_dnc,      Some(any_failure_will_do);
 );

--- a/tests/vca/zkp_functionality_tests/mod.rs
+++ b/tests/vca/zkp_functionality_tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod accumulator_test;
 pub mod test_definitions;
+pub mod blind_signing;


### PR DESCRIPTION
This PR adds to the DNC backend explicit proving and verification of knowledge of commitment blinders used for blind signing.  This is not necessary for AC2C schemes because they already implement it.  The README is updated to explain.

There are three commits:
* Add blind-signing test harness and initial tamper cases (AC2C BBS/PS, DNC); leaves rudimentary DNC tamper test failing to highlight missing proof-of-knowledge of blinding factors.
* Implement proof-of-knowledge of commitment blinders for DNC, making the primary DNC tamper test pass.  Makes DNC happy path test fail due to change of concrete type.
* Refine DNC tampering, repair DNC to/from_api handling so the DNC happy-path test passes again.  Now all tests pass.

